### PR TITLE
Added Custom Overdose Death Source

### DIFF
--- a/src/main/java/com/jetpacker06/CreateBrokenBad/CreateBrokenBad.java
+++ b/src/main/java/com/jetpacker06/CreateBrokenBad/CreateBrokenBad.java
@@ -1,5 +1,6 @@
 package com.jetpacker06.CreateBrokenBad;
 
+import com.jetpacker06.CreateBrokenBad.damage.ModDamageTypes;
 import com.jetpacker06.CreateBrokenBad.register.*;
 import com.tterrag.registrate.Registrate;
 import net.fabricmc.api.ClientModInitializer;

--- a/src/main/java/com/jetpacker06/CreateBrokenBad/damage/ModDamageTypes.java
+++ b/src/main/java/com/jetpacker06/CreateBrokenBad/damage/ModDamageTypes.java
@@ -10,9 +10,13 @@ import net.minecraft.world.level.Level;
 
 public class ModDamageTypes {
     public static final ResourceKey<DamageType> OVERDOSE_DAMAGE_TYPE = ResourceKey.create(Registries.DAMAGE_TYPE, new ResourceLocation("createbb", "overdose_damage"));
-    
-     public static DamageSource of(Level level, ResourceKey<DamageType> key) {
+
+    public static DamageSource of(Level level, ResourceKey<DamageType> key) {
          DamageType damageType = level.registryAccess().registryOrThrow(Registries.DAMAGE_TYPE).get(key);
          return new DamageSource(Holder.direct(damageType));
-     }
+    }
+
+    public static DamageSource overdoseDamage(Level level) {
+        return of(level, OVERDOSE_DAMAGE_TYPE);
+    }
 }

--- a/src/main/java/com/jetpacker06/CreateBrokenBad/damage/ModDamageTypes.java
+++ b/src/main/java/com/jetpacker06/CreateBrokenBad/damage/ModDamageTypes.java
@@ -1,0 +1,18 @@
+package com.jetpacker06.CreateBrokenBad.damage;
+
+import net.minecraft.core.Holder;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.ResourceKey;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.damagesource.DamageSource;
+import net.minecraft.world.damagesource.DamageType;
+import net.minecraft.world.level.Level;
+
+public class ModDamageTypes {
+    public static final ResourceKey<DamageType> OVERDOSE_DAMAGE_TYPE = ResourceKey.create(Registries.DAMAGE_TYPE, new ResourceLocation("createbb", "overdose_damage"));
+    
+     public static DamageSource of(Level level, ResourceKey<DamageType> key) {
+         DamageType damageType = level.registryAccess().registryOrThrow(Registries.DAMAGE_TYPE).get(key);
+         return new DamageSource(Holder.direct(damageType));
+     }
+}

--- a/src/main/java/com/jetpacker06/CreateBrokenBad/item/MethItem.java
+++ b/src/main/java/com/jetpacker06/CreateBrokenBad/item/MethItem.java
@@ -1,16 +1,16 @@
 package com.jetpacker06.CreateBrokenBad.item;
 
 import com.jetpacker06.CreateBrokenBad.block.TrayBlock;
+import com.jetpacker06.CreateBrokenBad.damage.ModDamageTypes;
 import com.jetpacker06.CreateBrokenBad.register.CBBBlocks;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.TextComponentTagVisitor;
-import net.minecraft.network.chat.Component;
 import net.minecraft.sounds.SoundEvents;
 import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
+import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
@@ -86,7 +86,8 @@ public class MethItem extends Item {
 
                 // If the count hits 0, kill the player
                 if(currentCount - 1 <= 0) {
-                    player.kill();
+                    DamageSource overdoseDamage = ModDamageTypes.of(player.level(), ModDamageTypes.OVERDOSE_DAMAGE_TYPE);
+                    player.die(overdoseDamage);
                 }
             } else {
                 // If the player does not have the MethItem effect, reset the count

--- a/src/main/java/com/jetpacker06/CreateBrokenBad/item/MethItem.java
+++ b/src/main/java/com/jetpacker06/CreateBrokenBad/item/MethItem.java
@@ -62,9 +62,6 @@ public class MethItem extends Item {
         return UseAnim.EAT; // Displays the eating animation when the player uses the item
     }
 
-    // Defines a unique effect for the MethItem (STILL NEED TO FINISH THIS)
-//    public static final MobEffect METH_EFFECT = new MobEffect(MobEffectCategory.BENEFICIAL, 0x98D982) {};
-
     @Override
     public @NotNull ItemStack finishUsingItem(@NotNull ItemStack stack, @NotNull Level world, @NotNull LivingEntity livingEntity) {
         // Add the speed effect to the player for 200 ticks (10 seconds) at amplifier 1
@@ -73,27 +70,29 @@ public class MethItem extends Item {
             int duration = (this instanceof MethItem.White) ? 300 : 1200;
             // amplified by 2 if white meth and 4 if blue meth
             int amplifier = (this instanceof MethItem.White) ? 2 : 4;
-            CompoundTag playerData = player.getCustomData();
 
             // checks if the player already has the methItem effect
-            if(player.hasEffect(MobEffects.MOVEMENT_SPEED)) {
-                // Gets the current count from the player's data
-                int currentCount = playerData.getInt("MethEffectCount");
+            if(!player.isCreative()) {
+                CompoundTag playerData = player.getCustomData();
 
-                // Increment the count and store it in the player's data
-                playerData.putInt("MethEffectCount", currentCount - 1);
+                if(player.hasEffect(MobEffects.MOVEMENT_SPEED)) {
+                    // Gets the current count from the player's data
+                    int currentCount = playerData.getInt("MethEffectCount");
 
-                // If the count hits 0, kill the player
-                if(currentCount - 1 <= 0) {
-                    player.hurt(ModDamageTypes.overdoseDamage(player.level()), Float.MAX_VALUE);
+                    // Increment the count and store it in the player's data
+                    playerData.putInt("MethEffectCount", currentCount + 1);
+
+                    // If the count hits 0, kill the player
+                    if(currentCount + 1 >= 5) {
+                        player.hurt(ModDamageTypes.overdoseDamage(player.level()), Float.MAX_VALUE);
+                    }
+                } else {
+                    // If the player does not have the MethItem effect, reset the count
+                    playerData.putInt("MethEffectCount", 0);
                 }
-            } else {
-                // If the player does not have the MethItem effect, reset the count
-                playerData.putInt("MethEffectCount", 5);
             }
 
-            // Still need to finish this!
-//            player.addEffect(new MobEffectInstance(METH_EFFECT, duration, 4));
+
             player.addEffect(new MobEffectInstance(MobEffects.MOVEMENT_SPEED, duration, amplifier));
 
             // Remove that instance of item from inventory

--- a/src/main/java/com/jetpacker06/CreateBrokenBad/item/MethItem.java
+++ b/src/main/java/com/jetpacker06/CreateBrokenBad/item/MethItem.java
@@ -10,7 +10,6 @@ import net.minecraft.sounds.SoundSource;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
 import net.minecraft.world.InteractionResultHolder;
-import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.effect.MobEffectInstance;
 import net.minecraft.world.effect.MobEffects;
 import net.minecraft.world.entity.LivingEntity;
@@ -86,8 +85,7 @@ public class MethItem extends Item {
 
                 // If the count hits 0, kill the player
                 if(currentCount - 1 <= 0) {
-                    DamageSource overdoseDamage = ModDamageTypes.of(player.level(), ModDamageTypes.OVERDOSE_DAMAGE_TYPE);
-                    player.die(overdoseDamage);
+                    player.hurt(ModDamageTypes.overdoseDamage(player.level()), Float.MAX_VALUE);
                 }
             } else {
                 // If the player does not have the MethItem effect, reset the count

--- a/src/main/resources/assets/createbb/lang/en_us.json
+++ b/src/main/resources/assets/createbb/lang/en_us.json
@@ -58,6 +58,8 @@
   "brass_call_bell_tooltip": "§8Ding!",
   "ephedra_tooltip": "§8Buy it from farmers.",
 
+  "death.attack.overdose": "%1$s overdosed on Methamphetamine!",
+
 
   "itemGroup.CreateBB": "Create: Broken Bad"
 }

--- a/src/main/resources/assets/createbb/lang/en_us.json
+++ b/src/main/resources/assets/createbb/lang/en_us.json
@@ -58,7 +58,7 @@
   "brass_call_bell_tooltip": "§8Ding!",
   "ephedra_tooltip": "§8Buy it from farmers.",
 
-  "death.attack.overdose": "%1$s overdosed on Methamphetamine!",
+  "death.attack.overdose": "%1$s overdosed on Methamphetamine",
 
 
   "itemGroup.CreateBB": "Create: Broken Bad"

--- a/src/main/resources/data/createbb/damage_type/overdose_damage.json
+++ b/src/main/resources/data/createbb/damage_type/overdose_damage.json
@@ -1,5 +1,5 @@
 {
-  "exhaustion": 0.1,
+  "exhaustion": 1,
   "message_id": "overdose",
   "scaling": "never"
 }

--- a/src/main/resources/data/createbb/damage_type/overdose_damage.json
+++ b/src/main/resources/data/createbb/damage_type/overdose_damage.json
@@ -1,0 +1,5 @@
+{
+  "exhaustion": 0.1,
+  "message_id": "overdose",
+  "scaling": "never"
+}


### PR DESCRIPTION
- Overdose death source now displays a custom message in chat and on the death screen when you die due to the meth item
- This system only kills users that are in survival mode and not creative mode